### PR TITLE
Replace require with a more precise require

### DIFF
--- a/lib/gzipped_tar/reader.rb
+++ b/lib/gzipped_tar/reader.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "stringio"
+require "zlib"
 
 module GZippedTar
   class Reader

--- a/lib/gzipped_tar/reader.rb
+++ b/lib/gzipped_tar/reader.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "stringio"
-require "rubygems/package"
 
 module GZippedTar
   class Reader

--- a/lib/gzipped_tar/tar/bounded_stream.rb
+++ b/lib/gzipped_tar/tar/bounded_stream.rb
@@ -26,7 +26,7 @@ class GZippedTar::Tar::BoundedStream
   def write(data)
     if data.bytesize + @written > @limit
       raise GZippedTar::Tar::FileOverflow,
-        "You tried to feed more data than fits in the file."
+            "You tried to feed more data than fits in the file."
     end
     @io.write data
     @written += data.bytesize

--- a/lib/gzipped_tar/tar/entry.rb
+++ b/lib/gzipped_tar/tar/entry.rb
@@ -55,7 +55,7 @@ class GZippedTar::Tar::Entry
   rescue ArgumentError => e
     raise unless e.message == "string contains null byte"
     raise GZippedTar::Tar::TarInvalidError,
-      "tar is corrupt, name contains null byte"
+          "tar is corrupt, name contains null byte"
   end
 
   # Read one byte from the tar entry

--- a/lib/gzipped_tar/tar/split_name.rb
+++ b/lib/gzipped_tar/tar/split_name.rb
@@ -51,8 +51,8 @@ class GZippedTar::Tar::SplitName
     return if string.bytesize <= maximum
 
     raise GZippedTar::Tar::TooLongFileName,
-      "File \"#{string}\" has a too long #{description} (should be " \
-      "#{maximum} or less)"
+          "File \"#{string}\" has a too long #{description} (should be " \
+          "#{maximum} or less)"
   end
 
   # If the file is less than MAXIMUM_NAME_LENGTH, it doesn't need to be split,

--- a/lib/gzipped_tar/writer.rb
+++ b/lib/gzipped_tar/writer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "stringio"
+require "zlib"
 
 module GZippedTar
   class Writer

--- a/lib/gzipped_tar/writer.rb
+++ b/lib/gzipped_tar/writer.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require "stringio"
-require "rubygems/package"
 
 module GZippedTar
   class Writer


### PR DESCRIPTION
For some yet unknown reason requiring the `ruybgems/package` instead of `zlib` broke a part of my app.

Can you please explain why you required `ruybgems/package` ?